### PR TITLE
fix: Elapsed hour is always printed as "1" and not increase

### DIFF
--- a/pbar.hpp
+++ b/pbar.hpp
@@ -314,7 +314,7 @@ class pbar {
 		u8cout_ << closing_bracket_char_ << " " << std::setw(digit_) << prog << "/" << total_;
 		if (enable_time_measurement_) {
 			u8cout_ << " [" << std::setfill('0');
-			if (auto dt_h = duration_cast<hours>(dt).count() > 0) {
+			if (auto dt_h = duration_cast<hours>(dt).count(); dt_h > 0) {
 				u8cout_ << dt_h << ':';
 			}
 			u8cout_ << std::setw(2) << duration_cast<minutes>(dt).count() % 60 << ':'


### PR DESCRIPTION
The library works great for my project, but I found an issue when displaying elapsed time over 2 hours.

Elapsed hours `dt_h` is calculated like this:
```c++
auto dt_h = duration_cast<hours>(dt).count() > 0
````
so `dt_h` is deduced as `bool`.